### PR TITLE
fix!: enforce HRP limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
-# Bech32
+# `Bech32`
 
-[![pub package](https://img.shields.io/pub/v/bech32.svg)](https://pub.dartlang.org/packages/bech32)
-[![CircleCI](https://circleci.com/gh/inapay/bech32.svg?style=svg)](https://circleci.com/gh/inapay/bech32)
-
-An implementation of the [BIP173 spec] for Segwit Bech32 address format.
+An implementation of the [BIP-173 specification](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki) for general and Segwit `Bech32` encoding that optionally allows for longer input data.
 
 ## Examples
 
@@ -15,7 +12,8 @@ An implementation of the [BIP173 spec] for Segwit Bech32 address format.
   // => 1
 ```
 
-The lightning [BOLT #11 spec] can have longer inputs than the [BIP173 spec] allows. Use the positional maxLength parameter to override the validation.
+The Lightning [BOLT #11 specification](https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md) permits longer inputs than are allowed by BIP-173.
+Use the positional `maxLength` parameter to override the default limit, which is 90 characters for the entire encoded string.
 ```dart
   String paymentRequest = "lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w";
   Bech32Codec codec = Bech32Codec();
@@ -27,30 +25,10 @@ The lightning [BOLT #11 spec] can have longer inputs than the [BIP173 spec] allo
   // => hrp: lnbc
 ```
 
+Even if you set `maxLength` to a longer value than the default, the human-readable encoding prefix is still limited to 83 characters.
+Modifying the length limit is not strictly compliant with BIP-173, but is fairly common in practice and consistent with other designs like the [ZIP-173 specification](https://zips.z.cash/zip-0173).
+
 ## Exceptions
 
-The specification defines a myriad of cases in which decoding and encoding 
-should fail. Please make sure your code catches all the relevant exception 
-defined in `lib/exceptions.dart`.
-
-## Installing
-
-Add it to your `pubspec.yaml`:
-
-```
-dependencies:
-  bech32: any
-```
-
-## Licence overview
-
-All files in this repository fall under the license specified in 
-[COPYING](COPYING). The project is licensed as [AGPL with a lesser clause](https://www.gnu.org/licenses/agpl-3.0.en.html). 
-It may be used within a proprietary project, but the core library and any 
-changes to it must be published online. Source code for this library must 
-always remain free for everybody to access.
-
-## Thanks
-
-[BIP173 spec]: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
-[BOLT #11 spec]: https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md
+The specification defines a myriad of cases in which decoding and encoding should fail.
+Please make sure your code catches all the relevant exception defined in `lib/exceptions.dart`.

--- a/lib/src/bech32.dart
+++ b/lib/src/bech32.dart
@@ -41,8 +41,12 @@ class Bech32Encoder extends Converter<Bech32, String> with Bech32Validations {
           hrp.length + data.length + 1 + Bech32Validations.checksumLength);
     }
 
-    if (hrp.isEmpty) {
+    if (hrp.length < Bech32Validations.minHrpLength) {
       throw TooShortHrp();
+    }
+
+    if (hrp.length > Bech32Validations.maxHrpLength) {
+      throw TooLongHrp();
     }
 
     if (hasOutOfRangeHrpCharacters(hrp)) {
@@ -93,6 +97,10 @@ class Bech32Decoder extends Converter<String, Bech32> with Bech32Validations {
       throw TooShortHrp();
     }
 
+    if (isHrpTooLong(separatorPosition)) {
+      throw TooLongHrp();
+    }
+
     input = input.toLowerCase();
 
     var hrp = input.substring(0, separatorPosition);
@@ -131,6 +139,8 @@ class Bech32Decoder extends Converter<String, Bech32> with Bech32Validations {
 
 /// Generic validations for Bech32 standard.
 mixin Bech32Validations {
+  static const minHrpLength = 1;
+  static const maxHrpLength = 83;
   static const int maxInputLength = 90;
   static const checksumLength = 6;
 
@@ -144,7 +154,11 @@ mixin Bech32Validations {
   }
 
   bool isHrpTooShort(int separatorPosition) {
-    return separatorPosition == 0;
+    return separatorPosition < minHrpLength;
+  }
+
+  bool isHrpTooLong(int separatorPosition) {
+    return separatorPosition > maxHrpLength;
   }
 
   bool isInvalidChecksum(String hrp, List<int> data, List<int> checksum) {

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -3,6 +3,12 @@ class TooShortHrp implements Exception {
   String toString() => 'The human readable part should have non zero length.';
 }
 
+class TooLongHrp implements Exception {
+  @override
+  String toString() =>
+      'The human readable part cannot exceed the maximum length.';
+}
+
 class TooLong implements Exception {
   TooLong(this.length);
 

--- a/test/bech32_test.dart
+++ b/test/bech32_test.dart
@@ -77,7 +77,7 @@ void main() {
             throwsA(TypeMatcher<InvalidSeparator>()));
       });
 
-      test('empty hpr', () {
+      test('empty hrp', () {
         expect(() => bech32.decode('1pzry9x0s0muk'),
             throwsA(TypeMatcher<TooShortHrp>()));
       });
@@ -102,14 +102,65 @@ void main() {
             throwsA(TypeMatcher<InvalidChecksum>()));
       });
 
-      test('empty hpr, case one', () {
+      test('empty hrp, case one', () {
         expect(() => bech32.decode('10a06t8'),
             throwsA(TypeMatcher<TooShortHrp>()));
       });
 
-      test('empty hpr, case two', () {
+      test('empty hrp, case two', () {
         expect(() => bech32.decode('1qzzfhee'),
             throwsA(TypeMatcher<TooShortHrp>()));
+      });
+    });
+
+    group('encoding errors', () {
+      test('too short hrp', () {
+        var invalid = Bech32('', []);
+        expect(
+            () => bech32.encode(invalid), throwsA(TypeMatcher<TooShortHrp>()));
+      });
+
+      test('too long hrp', () {
+        var invalid = Bech32(
+            'thishumanreadablepartexceedsthemaximumlengthallowedbythespecificationsoitshouldberejected',
+            []);
+        expect(() => bech32.encode(invalid, 100),
+            throwsA(TypeMatcher<TooLongHrp>()));
+      });
+
+      test('too long', () {
+        var invalid = Bech32(
+            'thishumanreadablepartexceedsthemaximumlengthallowedbythespecificationsoitshouldberejected',
+            []);
+        expect(() => bech32.encode(invalid), throwsA(TypeMatcher<TooLong>()));
+      });
+
+      test('invalid hrp character', () {
+        var invalid = Bech32(' ', []);
+        expect(() => bech32.encode(invalid),
+            throwsA(TypeMatcher<OutOfRangeHrpCharacters>()));
+      });
+
+      test('mixed-case hrp', () {
+        var invalid = Bech32('MiXeDcAsE', []);
+        expect(() => bech32.encode(invalid), throwsA(TypeMatcher<MixedCase>()));
+      });
+    });
+
+    group('decoding errors', () {
+      test('too long hrp', () {
+        expect(
+            () => bech32.decode(
+                'thishumanreadablepartexceedsthemaximumlengthallowedbythespecificationsoitshouldberejected1qpzrx6l5p5',
+                100),
+            throwsA(TypeMatcher<TooLongHrp>()));
+      });
+
+      test('mixed case', () {
+        expect(
+            () =>
+                bech32.decode('aBcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw'),
+            throwsA(TypeMatcher<MixedCase>()));
       });
     });
 


### PR DESCRIPTION
The [BIP-173 specification](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki) requires that the human-readable part (HRP) of a `Bech32` string not exceed 83 characters.

In the specification-compliant case where a `Bech32` string is limited to 90 characters overall, the library implicitly enforces this already. However, the library also allows for a non-compliant option where the overall string length may be specified by the caller. In this case, it's unclear which of the following should hold:
- The HRP is still limited to 83 characters in length
- The HRP is not limited in length, provided the overall string is otherwise valid

Currently, the library takes the latter approach. This PR takes the approach of other modified specifications like [ZIP-173](https://zips.z.cash/zip-0173) and retains the 83-character HRP limit, with the intent of better compatibility. It also adds encoding and decoding failure tests, as well as updates documentation.

This is a breaking change.